### PR TITLE
⬆️ Upgrade GitHub Actions dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+updates:
+- package-ecosystem: github-actions  # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
+  directory: /
+  groups:
+    GitHub-Actions:
+      update-types:
+        - major
+        - minor
+        - patch
+  schedule:
+    interval: monthly
+  target-branch: main

--- a/.github/workflows/deploy_pages.yml
+++ b/.github/workflows/deploy_pages.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '18'  # Use Node.js version 18 or later
 
@@ -45,7 +45,7 @@ jobs:
           cp -r dist/* docs/
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'docs'
 
@@ -58,4 +58,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
* 👷 Sets up <span title="Dependabot">![Dependabot](https://avatars.githubusercontent.com/in/29110?s=18&v=4)</span> for GitHub Actions
* ⬆️ Updates GitHub Actions with <span title="Dependabot">![Dependabot](https://avatars.githubusercontent.com/in/29110?s=18&v=4)</span>
* 👽️ Fixes ![Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/](https://github.com/user-attachments/assets/b9bd9403-fcdd-4d4f-8bec-ddd545df34a1)
